### PR TITLE
fix: Discord Webhook URLの取得方法を修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -311,7 +311,7 @@ async function main() {
   }
 
   // Notify to Discord new products and items
-  const discordWebhookUrl = Environment.getPath('DISCORD_WEBHOOK_URL')
+  const discordWebhookUrl = Environment.getValue('DISCORD_WEBHOOK_URL')
   if (discordWebhookUrl) {
     const discord = new Discord({
       webhookUrl: discordWebhookUrl,


### PR DESCRIPTION
Environment.getPathからEnvironment.getValueに変更し、
Discordの通知機能が正しく動作するように修正しました。