### PR TITLE
fix: format product names in new products display

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -320,7 +320,7 @@ async function main() {
     const newProductEmbeds = {
       title: 'New Products',
       fields: newProducts.map((product) => ({
-        name: product.productName,
+        name: `\`${product.productName}\``,
         value: `https://booth.pm/items/${product.productId}`,
         inline: false,
       })),
@@ -339,10 +339,13 @@ async function main() {
           (item) => item.product.productId === productId
         )
         return {
-          name: `${product?.productName} - https://booth.pm/items/${productId}`,
-          value: newProductItems
-            .map((item) => `- ${item.itemName} [${item.itemId}]`)
-            .join('\n'),
+          name: `\`${product?.productName}\``,
+          value:
+            `https://booth.pm/items/${productId}` +
+            '\n\n' +
+            newProductItems
+              .map((item) => `- ${item.itemName} [${item.itemId}]`)
+              .join('\n'),
           inline: false,
         }
       }),


### PR DESCRIPTION
- Wrap product names in backticks for better readability.
- Update the display format for product links and item details.