### PR TITLE
feat: add support for fetching free items from wishlists

### DIFF
--- a/src/booth.test.ts
+++ b/src/booth.test.ts
@@ -501,4 +501,85 @@ describe('BoothParser', () => {
       items: [],
     })
   })
+
+  // 欲しいものリストJSONのパースをテスト
+  test('should parse wishlist JSON', () => {
+    const mockJson = {
+      items: [
+        {
+          product: {
+            id: 11_111,
+            name: 'Product 1',
+            url: 'https://booth.pm/ja/items/11111',
+            images: [
+              {
+                original: 'https://example.com/thumb1.jpg',
+                resized: 'https://example.com/thumb1_resized.jpg',
+              },
+            ],
+            shop: {
+              name: 'Shop 1',
+              url: 'https://shop1.booth.pm/',
+            },
+          },
+        },
+        {
+          product: {
+            id: 22_222,
+            name: 'Product 2',
+            url: 'https://booth.pm/ja/items/22222',
+            images: [
+              {
+                original: 'https://example.com/thumb2.jpg',
+              },
+            ],
+            shop: {
+              name: 'Shop 2',
+              url: 'https://shop2.booth.pm/',
+            },
+          },
+        },
+      ],
+    }
+
+    const result = boothParser.parseWishlistJson(mockJson)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      productId: '11111',
+      productName: 'Product 1',
+      productURL: 'https://booth.pm/ja/items/11111',
+      thumbnailURL: 'https://example.com/thumb1.jpg',
+      shopName: 'Shop 1',
+      shopURL: 'https://shop1.booth.pm/',
+      items: [],
+    })
+    expect(result[1]).toMatchObject({
+      productId: '22222',
+      productName: 'Product 2',
+      productURL: 'https://booth.pm/ja/items/22222',
+      thumbnailURL: 'https://example.com/thumb2.jpg',
+      shopName: 'Shop 2',
+      shopURL: 'https://shop2.booth.pm/',
+      items: [],
+    })
+  })
+
+  // 欲しいものリストJSONで商品が見つからない場合のテスト
+  test('should return empty array if no products in wishlist JSON', () => {
+    const mockJson = {
+      items: [],
+    }
+
+    const result = boothParser.parseWishlistJson(mockJson)
+    expect(result).toEqual([])
+  })
+
+  // 欲しいものリストJSONが不正な場合のテスト
+  test('should handle invalid wishlist JSON', () => {
+    expect(boothParser.parseWishlistJson(null)).toEqual([])
+    expect(boothParser.parseWishlistJson({})).toEqual([])
+    expect(boothParser.parseWishlistJson({ items: null })).toEqual([])
+    expect(boothParser.parseWishlistJson({ items: 'not array' })).toEqual([])
+  })
 })

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -62,6 +62,10 @@ export class Environment {
       value: process.env.FREE_ITEMS_PATH ?? 'data/free-items.json',
       type: 'file',
     },
+    WISHLIST_URLS: {
+      value: process.env.WISHLIST_URLS ?? '',
+      type: 'string',
+    },
   } as const
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -588,17 +588,20 @@ describe('Main Functions', () => {
   })
 
   describe('fetchFreeItems', () => {
+    beforeEach(() => {
+      mockEnvironment.getValue.mockImplementation((key: string) => {
+        if (key === 'WISHLIST_URLS') return ''
+        return ''
+      })
+    })
+
     // 無料アイテムの設定ファイルが存在しない場合のテスト
-    test('should create empty free items file if not exists', async () => {
+    test('should handle no free items file and no wishlist', async () => {
       mockFs.existsSync.mockReturnValue(false)
 
       const result = await fetchFreeItems(boothRequest, boothParser, pageCache)
 
       expect(result).toEqual([])
-      expect(mockFs.writeFileSync).toHaveBeenCalledWith(
-        expect.any(String),
-        JSON.stringify({ freeItems: [] }, null, 2)
-      )
     })
 
     // 無料アイテムの設定ファイルが空の場合のテスト
@@ -764,6 +767,185 @@ describe('Main Functions', () => {
       const result = await fetchFreeItems(boothRequest, boothParser, pageCache)
 
       expect(result).toEqual([])
+    })
+
+    // 欲しいものリストから無料アイテムを取得するテスト
+    test('should fetch free items from wishlist', async () => {
+      mockFs.existsSync.mockReturnValue(false)
+      mockEnvironment.getValue.mockImplementation((key: string) => {
+        if (key === 'WISHLIST_URLS')
+          return 'https://booth.pm/wish_list_names/test123'
+        return ''
+      })
+
+      // Mock wishlist JSON response
+      const mockWishlistJson = {
+        items: [
+          {
+            product: {
+              id: 88_888,
+              name: 'Wishlist Item 1',
+              url: 'https://booth.pm/ja/items/88888',
+              images: [{ original: 'https://example.com/thumb.jpg' }],
+              shop: { name: 'Shop', url: 'https://shop.booth.pm/' },
+            },
+          },
+        ],
+      }
+
+      // Mock product page HTML for free item check
+      const mockProductHtml = `
+        <html>
+          <head>
+            <meta property="og:image" content="https://example.com/thumb.jpg">
+          </head>
+          <body>
+            <h1 class="text-text-default">Wishlist Item 1</h1>
+            <a href="https://booth.pm/ja/shop/12345">
+              <span>Shop</span>
+            </a>
+            <div>
+              <a href="https://booth.pm/downloadables/77777"></a>
+            </div>
+          </body>
+        </html>
+      `
+
+      jest.spyOn(boothRequest, 'getPublicWishlistJson').mockResolvedValue({
+        status: 200,
+        data: mockWishlistJson,
+      } as any)
+
+      jest
+        .spyOn(pageCache, 'loadOrFetch')
+        .mockResolvedValueOnce(mockWishlistJson) // wishlist response
+        .mockResolvedValueOnce(mockProductHtml) // product page for free check
+        .mockResolvedValueOnce(mockProductHtml) // product page for fetching
+
+      jest.spyOn(boothParser, 'parseWishlistJson').mockReturnValue([
+        {
+          productId: '88888',
+          productName: 'Wishlist Item 1',
+          productURL: 'https://booth.pm/ja/items/88888',
+          thumbnailURL: 'https://example.com/thumb.jpg',
+          shopName: 'Shop',
+          shopURL: 'https://shop.booth.pm/',
+          items: [],
+        },
+      ])
+
+      jest.spyOn(boothParser, 'parseFreeItemPage').mockReturnValue({
+        productId: '88888',
+        productName: 'Wishlist Item 1',
+        productURL: 'https://booth.pm/ja/items/88888',
+        thumbnailURL: 'https://example.com/thumb.jpg',
+        shopName: 'Shop',
+        shopURL: 'https://shop.booth.pm/',
+        items: [
+          {
+            itemId: '77777',
+            itemName: 'free_item.zip',
+            downloadURL: 'https://booth.pm/downloadables/77777',
+          },
+        ],
+      })
+
+      const result = await fetchFreeItems(boothRequest, boothParser, pageCache)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        productId: '88888',
+        productName: 'Wishlist Item 1',
+        type: 'free',
+      })
+    })
+
+    // 複数の欲しいものリストURLを処理するテスト
+    test('should handle multiple wishlist URLs', async () => {
+      mockFs.existsSync.mockReturnValue(false)
+      mockEnvironment.getValue.mockImplementation((key: string) => {
+        if (key === 'WISHLIST_URLS') {
+          return 'https://booth.pm/wish_list_names/list1,https://booth.pm/wish_list_names/list2'
+        }
+        return ''
+      })
+
+      // Mock wishlist responses
+      const mockWishlistJson1 = {
+        items: [
+          {
+            product: {
+              id: 11_111,
+              name: 'Item 1',
+              url: 'https://booth.pm/ja/items/11111',
+            },
+          },
+        ],
+      }
+      const mockWishlistJson2 = {
+        items: [
+          {
+            product: {
+              id: 22_222,
+              name: 'Item 2',
+              url: 'https://booth.pm/ja/items/22222',
+            },
+          },
+        ],
+      }
+
+      jest
+        .spyOn(boothRequest, 'getPublicWishlistJson')
+        .mockResolvedValueOnce({ status: 200, data: mockWishlistJson1 } as any)
+        .mockResolvedValueOnce({ status: 200, data: mockWishlistJson2 } as any)
+
+      jest
+        .spyOn(pageCache, 'loadOrFetch')
+        .mockImplementation(async (type, _id, _expiry, fetchFunc) => {
+          if (type === 'wishlist') {
+            return fetchFunc()
+          }
+          return '<html>Mock Product Page</html>'
+        })
+
+      jest
+        .spyOn(boothParser, 'parseWishlistJson')
+        .mockReturnValueOnce([
+          {
+            productId: '11111',
+            productName: 'Item 1',
+            productURL: 'https://booth.pm/ja/items/11111',
+            thumbnailURL: '',
+            shopName: '',
+            shopURL: '',
+            items: [],
+          },
+        ])
+        .mockReturnValueOnce([
+          {
+            productId: '22222',
+            productName: 'Item 2',
+            productURL: 'https://booth.pm/ja/items/22222',
+            thumbnailURL: '',
+            shopName: '',
+            shopURL: '',
+            items: [],
+          },
+        ])
+
+      jest.spyOn(boothParser, 'parseFreeItemPage').mockReturnValue({
+        productId: '',
+        productName: '',
+        productURL: '',
+        thumbnailURL: '',
+        shopName: '',
+        shopURL: '',
+        items: [{ itemId: '1', itemName: 'free.zip', downloadURL: '' }],
+      })
+
+      const result = await fetchFreeItems(boothRequest, boothParser, pageCache)
+
+      expect(result).toHaveLength(2)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add functionality to automatically retrieve free items from multiple wishlists
- Add WISHLIST_URLS environment variable to specify wishlist URLs
- Implement getPublicWishlistJson() method using JSON API endpoint  
- Update fetchFreeItems() to combine free-items.json and wishlist sources

## Test plan
- [x] Add comprehensive test coverage for wishlist functionality
- [x] Verify JSON API endpoint works correctly
- [x] Test with both existing free-items.json and new wishlist sources
- [ ] Test with actual wishlist URLs in production environment

🤖 Generated with [Claude Code](https://claude.ai/code)