### PR TITLE
fix: disable caching for library and gift page fetching

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ export async function fetchPurchased(
     const html = await pageCache.loadOrFetch(
       'library',
       pageNumber.toString(),
-      1,
+      null,
       async () => {
         const response = await boothRequest.getLibraryPage(pageNumber)
         if (response.status !== 200) {
@@ -56,7 +56,7 @@ export async function fetchPurchased(
     const html = await pageCache.loadOrFetch(
       'gift',
       pageNumber.toString(),
-      1,
+      null,
       async () => {
         const response = await boothRequest.getLibraryGiftsPage(pageNumber)
         if (response.status !== 200) {


### PR DESCRIPTION
## Summary
- 購入済み商品（ライブラリ）とギフトの一覧取得でキャッシュを無効化
- PageCacheのexpireDaysパラメータを1からnullに変更

## 解決する問題
10分ごとの取得処理に対して1日間のキャッシュが設定されていたため、実際の更新頻度が悪くなっていました。

## テスト計画
- [x] lintとtypecheckのパス確認
- [x] 既存テストの動作確認（テストではPageCacheがモックされているため変更影響なし）

Closes #175

🤖 Generated with [Claude Code](https://claude.ai/code)