### PR TITLE
fix: pnpm v11 対応のため Dockerfile のベースイメージを node:22-alpine に更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM zenika/alpine-chrome:with-puppeteer-xvfb AS runner
+# pnpm v11 は Node.js 22+ が必要なため、node:22-alpine をベースイメージとして使用する
+FROM node:22-alpine
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
@@ -6,14 +7,24 @@ ENV PATH="$PNPM_HOME/bin:$PATH"
 # hadolint ignore=DL3002
 USER root
 
-# hadolint ignore=DL3018,DL3016
+# hadolint ignore=DL3018
 RUN apk upgrade --no-cache --available && \
   apk update && \
-  apk add --update --no-cache tzdata x11vnc zip unzip && \
+  apk add --update --no-cache \
+    chromium \
+    chromium-swiftshader \
+    ttf-freefont \
+    font-noto-emoji \
+    font-wqy-zenhei \
+    tini \
+    xvfb \
+    x11vnc \
+    tzdata \
+    zip \
+    unzip && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
-  npm install -g corepack && \
   corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
## 変更概要

pnpm v11 は Node.js 22+ を必要としますが、従来のベースイメージ `zenika/alpine-chrome:with-puppeteer-xvfb` に含まれる Node.js は v20.15.1 であり、pnpm v11 実行時に `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` エラーが発生します。

Renovate PR #792 (`chore(deps): update pnpm to v11`) の Docker CI が以下のエラーで失敗しています:

```
TypeError [ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING]: A dynamic import callback was not specified.
    at /root/.cache/node/corepack/v1/pnpm/11.1.3/bin/pnpm.cjs:3:1
Node.js v20.15.1
```

## 変更内容

- **ベースイメージを変更**: `zenika/alpine-chrome:with-puppeteer-xvfb` → `node:22-alpine` (Node.js v22.22.3)
- **必要なパッケージを apk で手動インストール**:
  - `chromium` + `chromium-swiftshader`: Puppeteer 用 Chromium ブラウザ
  - `xvfb`: 仮想フレームバッファ (ヘッドレスブラウザ動作に使用)
  - `tini`: プロセス管理 (ENTRYPOINT で使用中)
  - `x11vnc`, `zip`, `unzip`, `tzdata`: 従来と同じユーティリティ
  - `ttf-freefont`, `font-noto-emoji`, `font-wqy-zenhei`: フォント (zenika イメージが提供していたもの)
- **`npm install -g corepack` を削除**: `node:22-alpine` には corepack が標準搭載 (v0.34.6)
- **不要な hadolint 無効化コメント (`DL3016`) を削除**: `npm install -g` が不要になったため

## 動作確認

ローカルで `docker build --platform linux/amd64` によるビルドが成功し、以下を確認:
- `node --version`: `v22.22.3`
- `/usr/bin/chromium-browser`: シンボリックリンクが正常に存在
- `tini`: `/sbin/tini` に存在
- `puppeteer-core`: `/app/node_modules/puppeteer-core` に正常インストール済み

## 関連 PR

- Renovate PR #792: `chore(deps): update pnpm to v11` — 本 PR によって Docker CI が通過可能になる