### PR TITLE
fix: TypeScript v6 対応のため tsconfig に ignoreDeprecations と rootDir を追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Node",
     "lib": ["ESNext", "esnext.AsyncIterable", "DOM"],
     "outDir": "./dist",
+    "rootDir": ".",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -26,7 +27,8 @@
     "newLine": "LF",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*", "__mocks__/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src/**/*", "__mocks__/**/*"]
 }


### PR DESCRIPTION
## 概要

Renovate PR #733 (`chore(deps): update dependency typescript to v6`) で発生している TypeScript v6 互換性エラーを解消するため、`tsconfig.json` を修正します。

## 変更内容

### `tsconfig.json`

| 項目 | 変更 |
|------|------|
| `rootDir` | 追加: `"."` |
| `ignoreDeprecations` | 追加: `"5.0"` |

## 解消されるエラー

TypeScript v6 では以下の設定が廃止エラーになります:

- **TS5107**: `moduleResolution=node10` (旧称 `Node`) が廃止
- **TS5101**: `baseUrl` が廃止 (`paths` と組み合わせた利用)
- **TS5011**: `rootDir` が明示的に設定されていない

`ignoreDeprecations: "5.0"` を追加することで、これらの廃止エラーを抑制します。
`rootDir: "."` を追加することで TS5011 を解消します。

## 技術的な補足

### `ignoreDeprecations` の値について

- `"5.0"` は TypeScript v5.x および v6.x の両方で有効な値です
- `"6.0"` は TypeScript v6.0 以降でのみ有効であり、現在の v5.x 環境では `TS5103: Invalid value` エラーになります
- `moduleResolution: Node` と `baseUrl` はどちらも TypeScript 5.0 時点で廃止予定となったため、`"5.0"` で両方をカバーできます

### `rootDir: "."` について

- `include` に `src/**/*` と `__mocks__/**/*` の両方が含まれているため、TypeScript はもともと共通の祖先である `.` を暗黙の `rootDir` として推論していました
- `rootDir: "."` の追加は既存の動作と一致しており、`dist` ディレクトリの出力構造に変更はありません
- プロジェクトの実行は `tsx` を直接使用しているため (`pnpm start` = `tsx ./src/main.ts`)、`tsc` でのコンパイル出力は実行時には使用されません

## 関連 PR

- Renovate PR #733: `chore(deps): update dependency typescript to v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)