### PR TITLE
fix(deps): update node-html-parser to v9 with declaration patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk upgrade --no-cache --available && \
 WORKDIR /app
 
 COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
+COPY patches patches
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint-plugin-promise": "7.3.0",
     "jest": "30.4.2",
     "jest-expect-message": "1.1.3",
-    "node-html-parser": "7.1.0",
+    "node-html-parser": "9.0.0",
     "prettier": "3.9.4",
     "puppeteer-core": "25.3.0",
     "run-z": "2.1.0",

--- a/patches/node-html-parser@9.0.0.patch
+++ b/patches/node-html-parser@9.0.0.patch
@@ -1,0 +1,19 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 2febc793f7b63a5ec7fb7b00f88656a68c69989e..e64f517773cf8467ab8313a713d340f345a4d2f4 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -374,13 +374,7 @@ declare class TextNode extends Node {
+ //#region src/index.d.ts
+ declare function parse(data: string, options?: Partial<Options>): HTMLElement;
+ declare namespace parse {
+-  var parse: typeof parse$1;
+-  var HTMLElement: typeof HTMLElement;
+-  var CommentNode: typeof CommentNode;
+-  var valid: typeof valid;
+-  var Node: typeof Node;
+-  var TextNode: typeof TextNode;
+-  var NodeType: typeof NodeType;
++  export { parse$1 as parse, HTMLElement, CommentNode, valid, Node, TextNode, NodeType };
+ }
+ //#endregion
+ export { CommentNode, HTMLElement, Node, NodeType, type Options, TextNode, parse as default, parse, valid };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  node-html-parser@9.0.0: c5d3312caab09dd29007cf479b0563da49556e34311b784d45d03be977e2eaba
+
 importers:
 
   .:
@@ -58,8 +61,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3
       node-html-parser:
-        specifier: 7.1.0
-        version: 7.1.0
+        specifier: 9.0.0
+        version: 9.0.0(patch_hash=c5d3312caab09dd29007cf479b0563da49556e34311b784d45d03be977e2eaba)
       prettier:
         specifier: 3.9.4
         version: 3.9.4
@@ -700,9 +703,6 @@ packages:
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
-
-  '@types/node@25.9.4':
-    resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
 
   '@types/node@25.9.5':
     resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
@@ -1354,6 +1354,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -1771,10 +1775,6 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
-
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2281,8 +2281,8 @@ packages:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
 
-  node-html-parser@7.1.0:
-    resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
+  node-html-parser@9.0.0:
+    resolution: {integrity: sha512-MhdaHPyxnyYu/sf0TpiRvDnTrkum0UKHC7FdbDGIUQNlx3I7xzwXoyV0eMUMv/XU+lkJT1glOUzpDPq7b2p1Ew==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -3513,7 +3513,7 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 25.9.5
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1':
@@ -3600,7 +3600,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.4
+      '@types/node': 25.9.5
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -3736,10 +3736,6 @@ snapshots:
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
-
-  '@types/node@25.9.4':
-    dependencies:
-      undici-types: 7.24.6
 
   '@types/node@25.9.5':
     dependencies:
@@ -4408,6 +4404,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@8.0.0: {}
+
   environment@1.1.0: {}
 
   error-ex@1.3.4:
@@ -4997,8 +4995,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  he@1.2.0: {}
-
   html-escaper@2.0.2: {}
 
   human-signals@2.1.0: {}
@@ -5326,7 +5322,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.9.4
+      '@types/node': 25.9.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5476,7 +5472,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.9.4
+      '@types/node': 25.9.5
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -5504,7 +5500,7 @@ snapshots:
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 25.9.5
       '@ungap/structured-clone': 1.3.2
       jest-util: 30.4.1
       merge-stream: 2.0.0
@@ -5683,10 +5679,10 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
-  node-html-parser@7.1.0:
+  node-html-parser@9.0.0(patch_hash=c5d3312caab09dd29007cf479b0563da49556e34311b784d45d03be977e2eaba):
     dependencies:
       css-select: 5.2.2
-      he: 1.2.0
+      entities: 8.0.0
 
   node-int64@0.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ allowBuilds:
   unrs-resolver: true
 minimumReleaseAgeExclude:
   - '@book000/*'
+patchedDependencies:
+  node-html-parser@9.0.0: patches/node-html-parser@9.0.0.patch


### PR DESCRIPTION
## Summary

Bumps `node-html-parser` 7.1.0 -> 9.0.0 (superseding Renovate PR #980, which is broken as-is) and adds a `pnpm patch` fix for a type-declaration bug introduced by the upgrade.

## Root cause

`node-html-parser` v8+ switched its build to `tsdown` (upstream issue [#311](https://github.com/taoqf/node-html-parser/issues/311)). The generated `dist/index.d.ts` re-exports its classes via a `declare namespace parse { var HTMLElement: typeof HTMLElement; ... }` block. Because these `var` declarations live inside the namespace's own scope, TypeScript resolves each `typeof X` to the var being declared itself rather than to the outer class/function of the same name -- a self-reference. This fails `tsc` with:

```
TS2502: 'HTMLElement' is referenced directly or indirectly in its own type annotation.
```

(also for `CommentNode`, `valid`, `Node`, `TextNode`, `NodeType`), which broke `Node CI / node-ci (.)` (`lint:tsc`) on #980.

## Fix

This repo's CLAUDE.md prohibits working around `tsc` errors with `skipLibCheck`, so instead of touching the project's own compiler options, this PR patches the vendored declaration file itself via `pnpm patch`: the broken namespace body is rewritten to use proper `export { X }` specifiers, which reference the outer scope directly and avoid the self-shadowing bug, instead of ambient `var` declarations. No runtime behavior changes; only the `.d.ts` is patched.

## Verification

- `pnpm exec tsc` -- exit 0 (previously 6 errors)
- `pnpm run lint` (prettier + eslint + tsc) -- clean
- `pnpm run test` -- 97 passed / 7 skipped, no failures

Only usage of `node-html-parser` in `src/booth.ts` is `import { parse as parseHtml } from 'node-html-parser'`, API-compatible across 7 -> 9.

This PR does not touch/replace Renovate PR #980's own branch.