### PR TITLE
fix(vpm-converter): reorder conditions for unicorn/prefer-simple-condition-first

### DIFF
--- a/src/vpm-converter.ts
+++ b/src/vpm-converter.ts
@@ -404,15 +404,15 @@ export class VpmConverter {
 
     // 判定ロジック
     if (
-      materialFiles > 0 &&
       codeFiles === 0 &&
+      materialFiles > 0 &&
       fileCount < VpmConverter.MAX_TEXTURE_ONLY_FILES
     ) {
       // マテリアル・テクスチャファイルが多く、コードファイルがない場合
       return 'texture-material'
     }
 
-    if (codeFiles > 0 && materialFiles === 0) {
+    if (materialFiles === 0 && codeFiles > 0) {
       // コードファイルが多く、マテリアルファイルがない場合
       return 'scripts'
     }


### PR DESCRIPTION
## 概要

Renovate PR #1007（`@book000/eslint-config` を 1.16.14 へ更新）で CI が失敗していた原因を修正する。

## 原因

`@book000/eslint-config` 1.16.14 で新たに有効化された `unicorn/prefer-simple-condition-first` ルールが、`src/vpm-converter.ts` の2箇所の `&&` 条件式（複雑な条件が単純な条件より先に書かれている）を検出し、lint エラーとなっていた。

## 対応

該当する2箇所の条件式の順序を入れ替え、単純な条件（`=== 0`）を先に評価するようにした。純粋な真偽値式であり副作用がないため、`&&` の可換性からロジックの挙動に変更はない。

- `src/vpm-converter.ts:407-409`: `materialFiles > 0 && codeFiles === 0 && ...` → `codeFiles === 0 && materialFiles > 0 && ...`
- `src/vpm-converter.ts:415`: `codeFiles > 0 && materialFiles === 0` → `materialFiles === 0 && codeFiles > 0`

修正後、`npx eslint src/vpm-converter.ts` でエラーなしを確認済み。

Renovate PR #1007 とは無関係の別ブランチ・別 PR として作成している（Renovate PR 自体へのコミットは行わない）。
