### PR TITLE
chore(git): add .worktreeinclude for local-only files

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+data/cookies.json
+data/free-items.json


### PR DESCRIPTION
## 概要

各 worktree で個別に保持すべきローカル専用ファイルを `git worktree` 作成時に自動コピーできるよう、`.worktreeinclude` を追加します。

## 追加したパターン

- `.env`
- `data/cookies.json`
- `data/free-items.json`

## 根拠

- `CLAUDE.md:98` - `.env` や `data/cookies.json` はコミット対象から除外する。
- `CLAUDE.md:91` - 認証情報は `data/cookies.json` に永続化される。
- `CLAUDE.md:96` - `BOOTH_EMAIL`, `BOOTH_PASSWORD` などの認証情報をコードやコミットに含めない。
- `README.md:28` - `.env` ファイルで `WISHLIST_IDS` を設定する記載あり。
- `src/environment.ts` は `process.env.*` を直接参照しており、dotenv 系パッケージの依存はないため `.env` は外部から読み込まれる想定。
- `.gitignore` に `.env` 系ファイルおよび `data/` ディレクトリ全体が含まれている。
- `compose.yaml` で `./data:/data` をボリュームマウントしており、`data/` 配下が永続化されたローカル状態であることを裏付けている。
- `.env.example` 等のテンプレートファイルは存在しない。

`data/cookies.json` は BOOTH へのログインセッションを保持する認証情報であり、失われると `BOOTH_EMAIL`/`BOOTH_PASSWORD` による再ログインが必要になります。`data/free-items.json` はユーザーが手動で管理する無料商品 ID の設定ファイルです。`data/products.json` や `cache/` などの再生成可能な出力ファイルは対象から除外しています。

参考: https://github.com/book000/book000/issues/132

## レビュー状況

- lite-review: 指摘事項なし
